### PR TITLE
Minor changes: replacing `:use` by `:refer :all`

### DIFF
--- a/src/leiningen/new/luminus/core/test/handler.clj
+++ b/src/leiningen/new/luminus/core/test/handler.clj
@@ -1,7 +1,7 @@
 (ns <<project-ns>>.test.handler
-  (:use clojure.test
-        ring.mock.request
-        <<project-ns>>.handler))
+  (:require [clojure.test :refer :all]
+            [ring.mock.request :refer :all]
+            [<<project-ns>>.handler :refer :all]))
 
 (deftest test-app
   (testing "main route"


### PR DESCRIPTION
Following Clojure style guidance to require namespaces.